### PR TITLE
fix memory leak

### DIFF
--- a/AcceptSDK/Network/AccepSDKtHttp.swift
+++ b/AcceptSDK/Network/AccepSDKtHttp.swift
@@ -118,7 +118,7 @@ class HTTP: NSObject, URLSessionDelegate {
         })
         task.resume()
         _ = semaphore.wait(timeout: DispatchTime.distantFuture)
-      session.finishTasksAndInvalidate()
+        session.finishTasksAndInvalidate()
         return httpResponse
     }
 

--- a/AcceptSDK/Network/AccepSDKtHttp.swift
+++ b/AcceptSDK/Network/AccepSDKtHttp.swift
@@ -118,6 +118,7 @@ class HTTP: NSObject, URLSessionDelegate {
         })
         task.resume()
         _ = semaphore.wait(timeout: DispatchTime.distantFuture)
+      session.finishTasksAndInvalidate()
         return httpResponse
     }
 


### PR DESCRIPTION
In this [line](https://github.com/AuthorizeNet/accept-sample-ios/blob/master/Pods/AuthorizeNetAccept/AcceptSDK/Network/AccepSDKtHttp.swift#L95), class `HTTP` has been set as URLSession's delegate, and URLSessionDelegate is a strong reference property, not weak reference.

see more details in this [issue](https://github.com/AuthorizeNet/accept-sample-ios/issues/21)